### PR TITLE
Don't allow non-staging merges to prod

### DIFF
--- a/.github/workflows/prod-check.yaml
+++ b/.github/workflows/prod-check.yaml
@@ -1,0 +1,18 @@
+name: Only allow staging -> prod & !prod -> staging merges
+
+on:
+  pull_request:
+    branches:
+    - staging
+    - prod
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Only allow staging -> prod merges
+      run: |
+        # All branches *except* prod can be merged into staging
+        # *Only* staging can be merged into prod
+        echo "Merging ${GITHUB_HEAD_REF} into ${GITHUB_BASE_REF}"
+        python3 -c 'import os, sys; sys.exit(not(os.environ["GITHUB_HEAD_REF"] == "staging" if os.environ["GITHUB_BASE_REF"] == "prod" else os.environ["GITHUB_HEAD_REF"] != "prod"))'


### PR DESCRIPTION
Sometimes folks accidentally merge prod to staging,
or PRs directly to prod. This protects against that.

Ref #45