### PR TITLE
Collect prometheus stats from NFS server as well

### DIFF
--- a/support/values.yaml
+++ b/support/values.yaml
@@ -1,4 +1,13 @@
 prometheus:
+  # We were using network tags to restrict NFS access to just nodes from hub-cluster
+  # However, it turns out packets coming from *pods* are *not* tagged with that, just from the nodes!
+  # I'm guessing this is an intersection of how GKE works? I'm not sure.
+  # Either way, I allowed TCP to port 9100 from 10.0.0.0/8 and it works fine.
+  extraScrapeConfigs: |
+    - job_name: prometheus-nfsd-server
+      static_configs:
+        - targets:
+          - jupyterhub-2i2c-nfs-vm:9100
   networkPolicy:
     enabled: true
   alertmanager:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -164,6 +164,19 @@ resource "azurerm_network_security_group" "nfs_vm" {
     destination_port_range     = "2049"
     destination_address_prefix = azurerm_network_interface.nfs_vm.private_ip_address
   }
+  #
+  # Prometheus from internal network
+  security_rule {
+    access                     = "Allow"
+    direction                  = "Inbound"
+    name                       = "prometheus"
+    priority                   = 102
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    source_address_prefix      = "*"
+    destination_port_range     = "9100"
+    destination_address_prefix = azurerm_network_interface.nfs_vm.private_ip_address
+  }
 }
 
 resource "azurerm_network_interface_security_group_association" "main" {

--- a/terraform/nfs-playbook.yaml
+++ b/terraform/nfs-playbook.yaml
@@ -42,3 +42,8 @@
         dest: /etc/exports
         content: >
           /export/{{disk_name}} 10.0.0.0/8(all_squash,anonuid=1000,anongid=1000,no_subtree_check,rw,sync)
+
+    - name: Install prometheus-node-exporter
+      apt:
+        pkg:
+          - prometheus-node-exporter


### PR DESCRIPTION
The NFS server is our biggest single point of failure,
and we should keep a good eye on it.

Ref #51