### PR TITLE
Install shiny-server as well

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -113,6 +113,11 @@ RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb
 
+ENV SHINY_SERVER_URL https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.15.953-amd64.deb
+RUN curl --silent --location --fail ${SHINY_SERVER_URL} > /tmp/shiny-server.deb && \
+    dpkg -i /tmp/shiny-server.deb && \
+    rm /tmp/shiny-server.deb
+
 # Needed by many R libraries
 # Picked up from https://github.com/rocker-org/rocker/blob/9dc3e458d4e92a8f41ccd75687cd7e316e657cc0/r-rspm/focal/Dockerfile
 # libglpk40 for igraph


### PR DESCRIPTION
Just 'shiny' is not enough for jupyter-shiny-proxy