### PR TITLE
Add R packages to demo learnr

### DIFF
--- a/deployments/utoronto/image/install-jupyter-extensions.bash
+++ b/deployments/utoronto/image/install-jupyter-extensions.bash
@@ -5,6 +5,7 @@ jupyter labextension install --debug \
     @jupyter-widgets/jupyterlab-manager@2 \
     @jupyterlab/server-proxy@2.1.1 \
     jupyterlab-jupytext@1.2.1 \
+    jupyter-matplotlib@0.7.4 \
     qgrid2@1.1.3
 
 # Install jupyter-contrib-nbextensions

--- a/deployments/utoronto/image/install.R
+++ b/deployments/utoronto/image/install.R
@@ -74,7 +74,11 @@ cran_packages <- c(
   "tokenizers", "0.2.1",
   "urltools", "1.7.3",
   "xaringan", "0.19",
-  "XML", "3.99-0.3"
+  "XML", "3.99-0.3",
+  # For demoing 'learnr' shiny apps
+  # https://github.com/rstudio/learnr/tree/master/inst/tutorials
+  "Lahman", "8.0-0",
+  "dygraphs", "1.1.1.6"
 )
 
 github_packages <- c(


### PR DESCRIPTION
There's a lot of interest in using 'learnr'
to write shiny apps.
https://github.com/rstudio/learnr/tree/master/inst/tutorials
has some demos, and this installs the required packages for
that in the base image.