### PR TITLE
Install staplr

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -145,6 +145,11 @@ RUN apt-get update && \
         libxml2 \
         libzmq3-dev \
         libglpk40 > /dev/null
+# Needed by staplr R library
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    default-jdk > /dev/null && \
+    R CMD javareconf
 # R_LIBS_USER is set by default in /etc/R/Renviron, which RStudio loads.
 # We uncomment the default, and set what we wanna - so it picks up
 # the packages we install. Without this, RStudio doesn't see the packages

--- a/deployments/utoronto/image/install.R
+++ b/deployments/utoronto/image/install.R
@@ -78,7 +78,9 @@ cran_packages <- c(
   # For demoing 'learnr' shiny apps
   # https://github.com/rstudio/learnr/tree/master/inst/tutorials
   "Lahman", "8.0-0",
-  "dygraphs", "1.1.1.6"
+  "dygraphs", "1.1.1.6",
+  # From https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/65
+  "staplr", "3.1.0"
 )
 
 github_packages <- c(


### PR DESCRIPTION
This should allow loading and using *staplr* and *rJava*. 
Fixes https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/65