### PR TITLE
Install copula R pkg

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update -qq --yes && \
         libxss1 \
         > /dev/null
 
-# for kableExtra & partitions & prettydoc & RSelenium & scholar & showtext & stopwords
+# for kableExtra & partitions & prettydoc & RSelenium & scholar & showtext & stopwords & copula
 # See https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/25
 RUN apt-get update -qq --yes && \
     apt-get install --yes -qq \
@@ -103,6 +103,7 @@ RUN apt-get update -qq --yes && \
         libglpk-dev \
         libfreetype6-dev \
         libgit2-dev \
+        libgsl0-dev \
         > /dev/null
 
 WORKDIR /home/jovyan

--- a/deployments/utoronto/image/install.R
+++ b/deployments/utoronto/image/install.R
@@ -80,7 +80,8 @@ cran_packages <- c(
   "Lahman", "8.0-0",
   "dygraphs", "1.1.1.6",
   # From https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/65
-  "staplr", "3.1.0"
+  "staplr", "3.1.0",
+  "copula", "1.0-1"
 )
 
 github_packages <- c(


### PR DESCRIPTION
From Silvana via email:
> I want to install the copula package, which works using install.packages but then library(copula) fails with a statement that there is no package called copula.