### PR TITLE
Issue template to discourage support issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue---.md
+++ b/.github/ISSUE_TEMPLATE/general-issue---.md
@@ -1,0 +1,14 @@
+---
+name: "General issue \U0001F4A1"
+about: An issue to propose changes to the infrastructure
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+🚨🚨 THIS SHOULD NOT BE A SUPPORT ISSUE 🚨🚨
+
+If you have questions about the Toronto hub, wish to report problems, or would like the environment updated, please email support@2i2c.org . We do not regularly check the issues in this repository!
+-->


### PR DESCRIPTION
This is an issue template to discourage people from opening support issues in this repository. It tries to redirect people to email `support@2i2c.org`.