### PR TITLE
Pin R to 4.0

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -55,7 +55,9 @@ RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
     r-base-core=${R_VERSION} \
     r-base-dev=${R_VERSION} \
-    r-cran-littler=0.3.11-1.2004.0 > /dev/null
+    r-cran-littler=0.3.11-1.2004.0 \
+    nodejs \
+    npm > /dev/null
 
 # Install desktop packages
 RUN apt-get update -qq --yes > /dev/null && \

--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -42,18 +42,20 @@ RUN echo "${LC_ALL} UTF-8" > /etc/locale.gen && \
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 
+
 # Install R packages
 # Our pre-built R packages from rspm are built against system libs in focal
 # rstan takes forever to compile from source, and needs libnodejs
-# So we install older (10.x) nodejs from apt rather than newer from conda
+# We don't want R 4.1 yet - the graphics protocol version it has is incompatible
+# with the version of RStudio we use. So we pin R to 4.0.5
+ENV R_VERSION=4.0.5-1.2004.0
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
-    r-base \
-    r-base-dev \
-    r-recommended \
-    r-cran-littler \
-    nodejs \
-    npm
+    r-base-core=${R_VERSION} \
+    r-base-dev=${R_VERSION} \
+    r-cran-littler=0.3.11-1.2004.0 > /dev/null
 
 # Install desktop packages
 RUN apt-get update -qq --yes > /dev/null && \
@@ -122,10 +124,9 @@ RUN apt-get update -qq --yes && \
         lsb-release \
         libclang-dev  > /dev/null
 
-# Set path where R packages are installed
-# Download and install rstudio manually
-# Newer one has bug that doesn't work with jupyter-rsession-proxy
-ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.2.5042-amd64.deb
+# 1.3.959 is latest version that works with jupyter-rsession-proxy
+# See https://github.com/jupyterhub/jupyter-rsession-proxy/issues/93#issuecomment-725874693
+ENV RSTUDIO_URL https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.3.959-amd64.deb
 RUN curl --silent --location --fail ${RSTUDIO_URL} > /tmp/rstudio.deb && \
     dpkg -i /tmp/rstudio.deb && \
     rm /tmp/rstudio.deb


### PR DESCRIPTION
The version of RStudio we were deploying is too old for
R 4.1's graphics engine, causing this error:

> R graphics engine version 14 is not supported by this version of RStudio. The Plots tab will be disabled until a newer version of RStudio is installed.

So we pin R to 4.0 until we can resolve that. The underlying
issue is tracked in https://github.com/jupyterhub/jupyter-rsession-proxy/issues/97