### PR TITLE
Fix RStudio install

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -55,7 +55,6 @@ RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
     r-base=${R_VERSION} \
     r-base-dev=${R_VERSION} \
-    r-base-core=${R_VERSION} \
     r-recommended=${R_VERSION} \
     r-cran-littler=0.3.11-1.2004.0 \
     nodejs \

--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -53,8 +53,10 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD5
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
-    r-base-core=${R_VERSION} \
+    r-base=${R_VERSION} \
     r-base-dev=${R_VERSION} \
+    r-base-core=${R_VERSION} \
+    r-recommended=${R_VERSION} \
     r-cran-littler=0.3.11-1.2004.0 \
     nodejs \
     npm > /dev/null

--- a/deployments/utoronto/image/environment.yml
+++ b/deployments/utoronto/image/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - pip:
     # Infrastructure things
     - jupyterlab==2.*
-    - voila==0.1.23
+    - voila==0.2.3
     - nbgitpuller==0.9.*
     - jupyter-resource-usage==0.5.1
     - nbinteract==0.2.5

--- a/deployments/utoronto/image/environment.yml
+++ b/deployments/utoronto/image/environment.yml
@@ -33,7 +33,6 @@ dependencies:
     - voila==0.2.3
     - nbgitpuller==0.9.*
     - jupyter-resource-usage==0.5.1
-    - nbinteract==0.2.5
     - jupytext==1.6.*
     - RISE==5.6.1
     - jupyter_contrib_nbextensions==0.5.1


### PR DESCRIPTION
Currently, starting RStudio throws:
![rstudio-error](https://user-images.githubusercontent.com/7579677/134500241-118eca72-fca1-4f14-9df9-353eff6f6228.png)

We were installing `r-recommended` and `r-base` before this error, so hopefully installing these might solve the issue.

### Update:

Bumped voila version, trying to solve the new issue observed [here](https://github.com/utoronto-2i2c/jupyterhub-deploy/pull/109#issuecomment-926001866)