### PR TITLE
Remove r-recommended package

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -55,7 +55,6 @@ RUN apt-get update -qq --yes > /dev/null && \
     apt-get install --yes -qq \
     r-base=${R_VERSION} \
     r-base-dev=${R_VERSION} \
-    r-recommended=${R_VERSION} \
     r-cran-littler=0.3.11-1.2004.0 \
     nodejs \
     npm > /dev/null


### PR DESCRIPTION
Hopefully this actually pins us to R 4.0. I *think* pinning r-recommended
to a particular version does not pin r-base, so just the latest version of r-base
gets installed. 

Ref https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/110