### PR TITLE
Pin R 4.0 harder

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -48,14 +48,19 @@ RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc
 # rstan takes forever to compile from source, and needs libnodejs
 # We don't want R 4.1 yet - the graphics protocol version it has is incompatible
 # with the version of RStudio we use. So we pin R to 4.0.5
+# littler, r-cran-mgcv, r-cran-survival, r-cran-matrix are specific packages needed
+# for apt to actually install the correct version of R 4.0.5
 ENV R_VERSION=4.0.5-1.2004.0
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list
 RUN apt-get update -qq --yes > /dev/null && \
-    apt-get install --yes -qq \
+    apt-get install --yes  --no-install-recommends \
     r-base=${R_VERSION} \
+    r-base-core=${R_VERSION} \
     r-base-dev=${R_VERSION} \
+    r-recommended=${R_VERSION} \
     r-cran-littler=0.3.11-1.2004.0 \
+    r-cran-mgcv r-cran-rpart r-cran-survival r-cran-matrix=1.3-3-1.2004.0 \
     nodejs \
     npm > /dev/null
 


### PR DESCRIPTION
Removing the -qq argument to `apt-get install` gives us
a useful error message on what packages were being installed.
r-base-core was getting a 4.1 version installed. Using the
`apt list -a r-base-core` command gave me versions that
were available, and I could pin it to the earlier version.

That gave me a new set of errors:

```
The following packages have unmet dependencies:
 r-recommended : Depends: r-cran-mgcv (>= 1.1.5) but it is not going to be installed
                 Depends: r-cran-rpart (>= 3.1.20) but it is not going to be installed
                 Depends: r-cran-survival (>= 2.13.2-1) but it is not going to be installed
                 Depends: r-cran-matrix but it is not going to be installed
```

I just specified all the packages, which gave me:

```
The following packages have unmet dependencies:
 r-cran-matrix : Depends: r-base-core (>= 4.1.0-1.2004.0) but 4.0.5-1.2004.0 is to be installed
E: Unable to correct problems, you have held broken packages.
```

I specified that version, and that has been
good enough now - R gives me version 4.0.5.

Ref https://github.com/utoronto-2i2c/jupyterhub-deploy/issues/110