### PR TITLE
Pin r-cran-mgcv to a version compatible with R4.0

### DIFF
--- a/deployments/utoronto/image/Dockerfile
+++ b/deployments/utoronto/image/Dockerfile
@@ -60,7 +60,8 @@ RUN apt-get update -qq --yes > /dev/null && \
     r-base-dev=${R_VERSION} \
     r-recommended=${R_VERSION} \
     r-cran-littler=0.3.11-1.2004.0 \
-    r-cran-mgcv r-cran-rpart r-cran-survival r-cran-matrix=1.3-3-1.2004.0 \
+    r-cran-mgcv=1.8-36-1cran1.2004.0 \
+    r-cran-rpart r-cran-survival r-cran-matrix=1.3-3-1.2004.0 \
     nodejs \
     npm > /dev/null
 


### PR DESCRIPTION
After the latest PR revert,  the image build is failing with ```you have held broken packages``` again.

The `apt install` output had this extra info about the error:
```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 r-cran-mgcv : Depends: r-base-core (>= 4.1.1-1.2004.0) but 4.0.5-1.2004.0 is to be installed
```
This PR pins r-cran-mgcv to a version that should be compatible with R 4.0