### PR TITLE
Merge #130 into prod (https://2i2c.freshdesk.com/a/tickets/49)

### DIFF
--- a/deployments/utoronto/image/install.R
+++ b/deployments/utoronto/image/install.R
@@ -50,6 +50,8 @@ cran_packages <- c(
   "multcomp", "1.4-17",
   "partitions", "1.10-2",
   "plotROC", "2.2.1",
+  # From https://2i2c.freshdesk.com/a/tickets/49
+  "polite", "0.1.1",
   "polynom", "1.4-0",
   "prettydoc", "0.4.1",
   "proto", "1.0.0",


### PR DESCRIPTION
Running `library(polite)` on the staging hub works without issues, so we should propagate the change to prod hub.

Reference: https://2i2c.freshdesk.com/a/tickets/49