### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 🔴 DEPRECATED - DO NOT USE THIS
+
+## UToronto hub is now deployed from ➡️ https://github.com/2i2c-org/infrastructure
+
 # 2i2c JupyterHub for University of Toronto
 
 Check it out at [jupyter.utoronto.ca](https://jupyter.utoronto.ca)


### PR DESCRIPTION
Add a not in the README about this repo being deprecated then archive the repo.

**Note** I've just archived the template repo too https://github.com/utoronto-2i2c/homepage

Closes https://github.com/2i2c-org/infrastructure/issues/917